### PR TITLE
create a default prettier config to avoid code format clashing

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}


### PR DESCRIPTION
created a default prettier config, to avoid code reformat based on each vscode prettier configuration