### PR TITLE
Handle Nullable Username in User Creation Process

### DIFF
--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -61,7 +61,7 @@ export async function POST(req: Request) {
     const mongoUser = await createUser({
       clerkId: id,
       name: `${first_name}${last_name ? ` ${last_name}` : ""}`,
-      username: username!,
+      username: username || id,
       email: email_addresses[0].email_address,
       picture: image_url,
     });


### PR DESCRIPTION
This pull request addresses an issue encountered during user creation, particularly with Google sign-ins, where nullable usernames in webhook responses conflict with the mandatory username field in UserSchema.

Changes Made:

Introduced a fallback mechanism using the user_id as the default username when the webhook response returns null for the username.