### PR TITLE
Adding options for #5 steps in Clerk by: codegino

### DIFF
--- a/.env.setupApiKeys
+++ b/.env.setupApiKeys
@@ -21,9 +21,16 @@ NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=CLERK_PUBLISHABLE_KEY
 CLERK_SECRET_KEY=CLERK_SECRET_KEY
 
+# (OPTION 1) Using localtunnel
+# 5. Run: npx localtunnel --port 3000
+# 6. Copy the generated url
+# 7. Add Endpoint -> ${your-url}/api/webhook
+
+# (OPTION 2 | PREFERRED) Deploying to vercel
 # 5. Deploy your app to Vercel
 # 6. Get the DOMAIN_NAME of your app
 # 7. Add Endpoint -> https://<DOMAIN_NAME>.vercel.app/api/webhook
+
 # 8. Go to dashboard.clerk.com
 # 9. Click on "Webhooks" in the left sidebar
 # 10. Copy the value from the "Signing Secret" section below


### PR DESCRIPTION
Adding webhook to clerk

(OPTION 1) Using localtunnel
5. Run: npx localtunnel --port 3000
6. Copy the generated url
7. Add Endpoint -> ${your-url}/api/webhook

(OPTION 2 | PREFERRED) Deploying to vercel
5. Deploy your app to Vercel
6. Get the DOMAIN_NAME of your app
7. Add Endpoint -> https://<DOMAIN_NAME>.vercel.app/api/webhook